### PR TITLE
fix: parent and name mismatch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,7 @@ function parseRouteFile(baseDir: string, routeFile: string) {
   let segment = ''
   while (index < name.length) {
     let char = name[index]
-    //console.log({ char, state, subState, segment, url })
+    // console.log({ char, state, subState, segment, url })
     switch (state) {
       case 'START':
         // process existing segment
@@ -106,6 +106,9 @@ function parseRouteFile(baseDir: string, routeFile: string) {
         if (parentState === 'APPEND') {
           if (parent) {
             parent += '.'
+          }
+          if (segment.includes(':')) {
+            segment = segment.replace(':', '$')
           }
           parent += segment
         }


### PR DESCRIPTION
As 2ez pointed out here https://discord.com/channels/770287896669978684/770287896669978687
now fixed.

Fixed issue: https://github.com/kiliman/remix-flat-routes/issues/1

Solution:
routeMap  name was not matching with parent.