### PR TITLE
Remove `>` from installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package enables you to define your routes using the flat-routes convention.
 ## 🛠 Installation
 
 ```bash
-> npm install remix-flat-routes
+npm install remix-flat-routes
 ```
 
 ## ⚙️ Configuration


### PR DESCRIPTION
So you can use GitHub's copy button without having to edit the copied text.