### PR TITLE
docs(README): Add doctype to `remix.config.js` export

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Update your _remix.config.js_ file and use the custom routes config option.
 
 ```ts
 const { flatRoutes } = require('remix-flat-routes')
+
+/**
+ * @type {import("@remix-run/dev").AppConfig}
+ */
 module.exports = {
   // ignore all files in routes folder to prevent
   // default remix convention from picking up routes


### PR DESCRIPTION
Thought it would be useful to keep it when copy/pasting the configuration!