### PR TITLE
Ensure compatibility with Node.js v14 for routeSegments check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -453,7 +453,7 @@ export function getRouteSegments(
   // process remaining segment
   pushRouteSegment(routeSegment)
   // strip trailing .route segment
-  if (routeSegments.at(-1) === 'route') {
+  if (routeSegments[routeSegments.length - 1] === 'route') {
     routeSegments = routeSegments.slice(0, -1)
   }
   // if hasPlus, we need to strip the trailing segment if it starts with _
@@ -461,7 +461,11 @@ export function getRouteSegments(
   // this is to handle layouts in flat-files
   // _public+/_layout.tsx => _public.tsx
   // _public+/index.tsx => _public.index.tsx
-  if (!index && hasPlus && routeSegments.at(-1)?.startsWith('_')) {
+  if (
+    !index &&
+    hasPlus &&
+    routeSegments[routeSegments.length - 1]?.startsWith('_')
+  ) {
     routeSegments = routeSegments.slice(0, -1)
   }
   return routeSegments


### PR DESCRIPTION
This PR addresses the compatibility issue with Node.js v14 in the conditional check for route within the routeSegments array. The original code utilized the at() method, which is only supported in Node.js v16 and above. To ensure compatibility with v14, the following changes have been made:

- Replaced routeSegments.at(-1) with routeSegments[routeSegments.length - 1]

With this change, the code is now compatible with both Node.js v14 and v16+ environments. This project supports the Node.js versions that remix supports (^14.17.0, or >=16.0.0).

### Changes:
- Updated the conditional check in the relevant file to use bracket notation and length property instead of at() method
### Testing:

- Manually tested the updated code in Node.js v14 and v16 environments
- All existing tests pass

### Img

<img width="303" alt="스크린샷 2023-04-25 오후 5 14 55" src="https://user-images.githubusercontent.com/37052037/234219479-2124073d-5fc2-47a1-ab84-61500d7ac9ba.png">
<img width="774" alt="스크린샷 2023-04-25 오후 5 17 03" src="https://user-images.githubusercontent.com/37052037/234219536-a2862017-0969-4f2a-8376-3281f36c7a4a.png">

### ref link
- https://remix.run/docs/en/1.15.0/tutorials/blog#prerequisites
