### PR TITLE
feat: follow symlinks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -438,7 +438,7 @@ export function defaultVisitFiles(
 ) {
   for (let filename of fs.readdirSync(dir)) {
     let file = path.resolve(dir, filename)
-    let stat = fs.lstatSync(file)
+    let stat = fs.statSync(file)
 
     if (stat.isDirectory()) {
       defaultVisitFiles(file, visitor, baseDir)


### PR DESCRIPTION
# Allow symlinks

Allow to share routes using symlinks.

## Initialize the project.

```
npx @remix-run/dev@1.7.5 create ./remix-symlink
# ? What type of app do you want to create? Just the basics
# ? Where do you want to deploy? Choose Remix App Server if you're unsure; it's easy to change deployment targets.
# Cloudflare Workers
# ? TypeScript or JavaScript? TypeScript
# ? Do you want me to run `npm install`? Yes

cd ./remix-symlink
```
Make routes/index.tsx symlink.
```
mv app/routes app/routes_orig
mkdir app/routes
ln -s ${PWD}/app/routes_orig/index.tsx ${PWD}/app/routes/index.tsx
```
Show detected routes

`npx remix routes --json`

## Expected Behavior

The routes that is symlink is detected

```
❯ npx remix routes --json
[
  {
    "id": "root",
    "path": "",
    "file": "root.tsx",
    "children": [
      {
        "id": "routes/index",
        "index": true,
        "file": "routes/index.tsx"
      }
    ]
  }
]
```

## Actual Behavior
routes/index.tsx is not detected as routes even though it exists.

```
❯ npx remix routes --json
[
  {
    "id": "root",
    "path": "",
    "file": "root.tsx"
  }
]
```