### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install -D remix-flat-routes
 import { remixConfigRoutes } from "@react-router/remix-config-routes-adapter";
 import { flatRoutes } from "remix-flat-routes";
 
-export const routes = remixConfigRoutes((defineRoutes) => {
+export default remixConfigRoutes((defineRoutes) => {
   return flatRoutes("routes", defineRoutes, {/* options */});
 });
 ```


### PR DESCRIPTION
fixes this error: [react-router] Route config must be the default export in "routes.ts".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the `README.md` to reflect changes in the `remix-flat-routes` package.
	- Expanded documentation on new features in versions 0.5.0 and 0.5.1, including support for hybrid routes and extended route filenames.
	- Clarified installation and configuration instructions, emphasizing updates needed in the `_remix.config.js` file.
	- Enhanced API section with details on new parameters for the `flatRoutes` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->