### PR TITLE
Update remix routes adapter package/function in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@ package that will convert existing Remix file-based routes to the new config for
 To use your existing file-based routing, install the adapter and update `routes.ts` to wrap your adapter. 
 
 ```bash
-npm install -D @react-router/remix-config-routes-adapter
+npm install -D @react-router/remix-routes-option-adapter
 npm install -D remix-flat-routes
 ```
 
 ```ts
 // app/routes.ts
-import { remixConfigRoutes } from "@react-router/remix-config-routes-adapter";
+import { remixRoutesOptionAdapter } from "@react-router/remix-routes-option-adapter";
 import { flatRoutes } from "remix-flat-routes";
 
-export const routes = remixConfigRoutes((defineRoutes) => {
+export const routes = remixRoutesOptionAdapter((defineRoutes) => {
   return flatRoutes("routes", defineRoutes, {/* options */});
 });
 ```


### PR DESCRIPTION
We switched the name of the package to [@react-router/remix-routes-option-adapter](https://www.npmjs.com/package/@react-router/remix-config-routes-adapter)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the installation command for the adapter package to reflect the new name.
	- Enhanced documentation on routing features introduced in versions 0.5.0 and 0.5.1, including hybrid routes and extended route filenames.
	- Provided examples for the folder structure changes and new routing conventions.
	- Expanded API section with new options for configuring routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->