### PR TITLE
fix: RR7 example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install -D remix-flat-routes
 import { remixRoutesOptionAdapter } from "@react-router/remix-routes-option-adapter";
 import { flatRoutes } from "remix-flat-routes";
 
-export const routes = remixRoutesOptionAdapter((defineRoutes) => {
+export default remixRoutesOptionAdapter((defineRoutes) => {
   return flatRoutes("routes", defineRoutes, {
     ignoredRouteFiles: ['**/.*'], // Ignore dot files (like .DS_Store)
     //appDir: 'app',


### PR DESCRIPTION
The routes need to be the default export.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - The primary module export has been updated to a default export. Users importing this module will need to adjust their import statements accordingly.  
  - Note that the overall functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->